### PR TITLE
Update acts_as_hashids.gemspec

### DIFF
--- a/acts_as_hashids.gemspec
+++ b/acts_as_hashids.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.executables   = `git ls-files -- bin/*`.split("\n").map { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.required_ruby_version = ['>= 2.2.2', '< 2.5']
+  spec.required_ruby_version = ['>= 2.2.2', '< 2.6']
 
   spec.add_runtime_dependency 'hashids', '~> 1.0'
   spec.add_runtime_dependency 'activerecord', '>= 4.0', '< 6.0'


### PR DESCRIPTION
Blocking update to Ruby 2.5 for ta-web